### PR TITLE
Fix install plugin

### DIFF
--- a/src/steps/install-plugin/block.json
+++ b/src/steps/install-plugin/block.json
@@ -14,7 +14,7 @@
 	"attributes": {
 		"step": {
 			"type": "string",
-			"default": "install-plugin"
+			"default": "installPlugin"
 		},
 		"pluginZipFile": {
 			"type": "object",


### PR DESCRIPTION
fixes typo from `install-plugin` to `installPlugin`