### PR TITLE
Update install plugin icon

### DIFF
--- a/src/steps/install-plugin/block.json
+++ b/src/steps/install-plugin/block.json
@@ -5,7 +5,6 @@
 	"version": "0.1.0",
 	"title": "Install Plugin",
 	"category": "steps",
-	"icon": "admin-plugins",
 	"description": "Installs a WordPress plugin in the Playground",
 	"example": {},
 	"supports": {

--- a/src/steps/install-plugin/index.js
+++ b/src/steps/install-plugin/index.js
@@ -2,6 +2,7 @@
  * Wordpress dependencies.
  */
 import { registerBlockType } from '@wordpress/blocks';
+import { plugins } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -13,5 +14,6 @@ import metadata from './block.json';
  * Every block starts by registering a new block type definition.
  */
 registerBlockType(metadata.name, {
+	icon: plugins,
 	edit: Edit,
 });


### PR DESCRIPTION
block.json uses dashicon and the edit component uses @wordpress/icons

PR makes icons consistent and uses icons from @wordpress/icons

moving forward we will follow this as standard.
