### PR TITLE
Refactor: always show description regardless of placeholder selection

### DIFF
--- a/src/steps/reset-data/index.js
+++ b/src/steps/reset-data/index.js
@@ -24,7 +24,7 @@ import metadata from './block.json';
  *
  * @return {Element} Element to render.
  */
-function Edit({ isSelected }) {
+function Edit() {
 
 	return (
 		<p {...useBlockProps()}>


### PR DESCRIPTION
### Summary
This PR ensures the description in the reset step is always visible, regardless of placeholder selection, for better consistency and UX.

### Related Issue
Closes #86 

> [!NOTE]
> Screenshots are not included as the Playground preview link is generated below. 