### PR TITLE
Feat(editor): disable-block-directory suggestions functionality for blueprint post type

### DIFF
--- a/src/editor/disable-block-directory.js
+++ b/src/editor/disable-block-directory.js
@@ -1,0 +1,21 @@
+/**
+ * Disable Block Directory plugin for 'blueprint' post type.
+ */
+wp.domReady(() => {
+    const select = wp.data?.select;
+    const getPostType = () => select?.('core/editor')?.getCurrentPostType?.();
+
+    const tryUnregister = () => {
+        const postType = getPostType();
+        if (!postType) return;
+
+        if (postType === 'blueprint' && wp.plugins.getPlugin?.('block-directory')) {
+            wp.plugins.unregisterPlugin('block-directory');
+        }
+        // We only need to run this once.
+        unsubscribe?.();
+    };
+
+    const unsubscribe = wp.data?.subscribe(tryUnregister);
+    tryUnregister();
+});

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -1,3 +1,4 @@
 import './block-appender';
 import './sidebar';
 import './on-boarding';
+import './disable-block-directory';


### PR DESCRIPTION
### Summary
This PR introduces functionality to disable block directory suggestions for the `blueprint` post type within the editor. This ensures that users don’t see third-party or external block suggestions when editing blueprint posts, maintaining a more controlled and consistent editing experience.

### Related Issue
Closes #92

> [!NOTE]
> Screenshots are not included as the Playground preview link is generated below. 