### PR TITLE
Fix(blueprint-import): prevent auto block selection to keep sidebar focused

### DIFF
--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -156,7 +156,13 @@ export const handleBlueprintData = async (jsonData, createNotice, updateBlueprin
         const { validBlocks, invalidSteps } = validateBlueprintSteps(steps);
 
         if (validBlocks.length > 0) {
-            dispatch('core/block-editor').insertBlocks(validBlocks);
+            dispatch('core/block-editor').insertBlocks(
+                validBlocks,
+                undefined,
+                undefined,
+                false,
+                null
+            );
             createNotice(
                 'success',
                 __('Blueprint imported successfully.', 'wp-playground-blueprint-editor'),


### PR DESCRIPTION
### Summary
This PR prevents auto block seletion after importing a blueprint, keeping the sidebar focused for a better user experience.

### Related Issue
Closes #87 

> [!NOTE]
> Screenshots are not included as the Playground preview link is generated below. 