### PR TITLE
Fix: steps block not showing in inserter

### DIFF
--- a/src/steps/define-wp-config-consts/index.js
+++ b/src/steps/define-wp-config-consts/index.js
@@ -39,16 +39,15 @@ import {
 function Edit({ attributes, setAttributes, isSelected }) {
 	const { consts } = attributes;
 	const [isOpen, setIsOpen] = useState(false);
-	const [configList, updateConfigList] = useState(Object.entries(consts));
+	const [configList, updateConfigList] = useState(Object.entries(consts || {}));
 	const [selectedConfig, setSelectedConfig] = useState(undefined);
 
 	useEffect(() => {
-		setAttributes({ consts: keyValuePairsToObject(configList) });
-
-		if (!isSelected) {
-			handleClose();
+		const configObject = keyValuePairsToObject(configList);
+		if (JSON.stringify(consts) !== JSON.stringify(configObject)) {
+			setAttributes({ consts: configObject });
 		}
-	}, [configList, isSelected]);
+	}, [configList]);
 
 	const addConfig = () => {
 		addKeyValuePair(configList, updateConfigList);

--- a/src/steps/update-user-meta/index.js
+++ b/src/steps/update-user-meta/index.js
@@ -40,16 +40,15 @@ import {
 function Edit({ attributes, setAttributes, isSelected }) {
 	const { meta, userId } = attributes;
 	const [isOpen, setIsOpen] = useState(false);
-	const [metaList, updateMetaList] = useState(Object.entries(meta));
+	const [metaList, updateMetaList] = useState(Object.entries(meta || {}));
 	const [selectedMeta, setSelectedMeta] = useState(undefined);
 
 	useEffect(() => {
-		setAttributes({ meta: keyValuePairsToObject(metaList) });
-
-		if (!isSelected) {
-			handleClose();
+		const metaObject = keyValuePairsToObject(metaList);
+		if (JSON.stringify(meta) !== JSON.stringify(metaObject)) {
+			setAttributes({ meta: metaObject });
 		}
-	}, [metaList, isSelected]);
+	}, [metaList]);
 
 	const addOption = () => {
 		addKeyValuePair(metaList, updateMetaList);


### PR DESCRIPTION
### Summary
This PR fixes an issue where the Steps block was sometimes not visible in the inserter. The root cause was identified as a conflict between two blocks update-user-meta and config-const both attempting to call setAttributes inside a useEffect without proper checks. This caused a continuous update loop, preventing the Steps block from being registered and displayed correctly in the inserter.

### Related Issue
Closes #93 

> [!NOTE]
> Screenshots are not included as the Playground preview link is generated below. 