### PR TITLE
Fix: show single snackbar instead of two when importing blueprint

### DIFF
--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -283,7 +283,6 @@ const handleJsonDataSubmit = (data, updateBlueprintConfig, createNotice) => {
         extraLibraries: data.extraLibraries || false,
         plugins: data.plugins || undefined,
     });
-    createNotice('success', __('Blueprint configuration updated successfully!', 'wp-playground-blueprint-editor'), { type: 'snackbar' });
 };
 
 /**


### PR DESCRIPTION
### Summary
This PR refines the Blueprint import flow by consolidating multiple snackbar into one.

### Related Issue
Closes #85

> [!NOTE]
>  Screenshots are not included as the Playground preview link is generated below.